### PR TITLE
Battery status server

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ This procedure has been tested on ArchLinux ARM.
 pacman -S python python-virtualenv
 virtualenv .lfds_backend
 source .lfds_backend/bin/activate
-pip install flask flask-responses psutil
+pip install flask flask-responses psutil sarge
 ```
 
 After the execution of the previous commands,

--- a/server/free_disk_space.py
+++ b/server/free_disk_space.py
@@ -3,12 +3,39 @@
 from flask import Flask
 from flask.ext.responses import json_response
 import psutil
+import sarge
+import re
 
 app = Flask(__name__)
 
 @app.route("/space")
 def space():
     result = {"space": (100-psutil.disk_usage("/").percent)}
+    return json_response(result, status_code=200)
+
+@app.route("/battery")
+def battery():
+    result = {"battery_perc": -1, "remaining_seconds": -1, "temperature_c": -1, "adapter_on": None}
+    p = sarge.run("acpi --everything", stdout=sarge.Capture())
+    output = p.stdout.text
+
+    first_line = output.splitlines()[0].strip()
+    print(first_line)
+    batt_perc_raw = re.findall("(\d\d)%", first_line)
+    print(batt_perc_raw)
+    result["battery_perc"] = int(batt_perc_raw[0])
+
+    batt_remain_time = re.findall("(\d\d):(\d\d):(\d\d)", first_line)
+    result["remaining_seconds"] = (lambda x: x[0]*3600+x[1]*60+x[2])(list(map(int, batt_remain_time[0])))
+
+    temperature_raw = re.findall("Thermal .+(\d\d\.\d) degrees C", output)
+    print("temp", temperature_raw)
+    result["temperature_c"] = float(temperature_raw[0])
+
+    adapter_on_raw = re.findall("Adapter \d: (on-line|off-line)", output)[0]
+    print(adapter_on_raw)
+    result["adapter_on"] = (adapter_on_raw == "on-line") and True or False
+
     return json_response(result, status_code=200)
 
 if __name__ == "__main__":

--- a/server/free_disk_space.py
+++ b/server/free_disk_space.py
@@ -21,12 +21,15 @@ def battery():
 
     first_line = output.splitlines()[0].strip()
     print(first_line)
-    batt_perc_raw = re.findall("(\d\d)%", first_line)
+    batt_perc_raw = re.findall("(\d\d\d?)%", first_line)
     print(batt_perc_raw)
     result["battery_perc"] = int(batt_perc_raw[0])
 
-    batt_remain_time = re.findall("(\d\d):(\d\d):(\d\d)", first_line)
-    result["remaining_seconds"] = (lambda x: x[0]*3600+x[1]*60+x[2])(list(map(int, batt_remain_time[0])))
+    try:
+        batt_remain_time = re.findall("(\d\d):(\d\d):(\d\d)", first_line)
+        result["remaining_seconds"] = (lambda x: x[0]*3600+x[1]*60+x[2])(list(map(int, batt_remain_time[0])))
+    except IndexError:
+        result["remaining_seconds"] = -1
 
     temperature_raw = re.findall("Thermal .+(\d\d\.\d) degrees C", output)
     print("temp", temperature_raw)


### PR DESCRIPTION
This PR adds a new endpoint `/battery` to show battery- and thermal- related info.
The change is useful if you need to check the battery status and the temperature of your remote PC.

a new dependency ([sarge](https://pypi.python.org/pypi/sarge)) is now required: just use `pip install sarge`.
`acpi` (on Linux hosts) must be installed to use the new endpoint.

the endpoint returns a json. the format follows

```
{
    "battery_perc": integer, battery charge percentage,
    "remaining_seconds": integer, either a positive number or -1
    "temperature_c": float, the PC temperature in Celsius,
    "adapter_on": bool (true/false)
}
```
### Windows support

Unfortunately, this patch is Linux-only (I prefer Linux hosts). If you have a Windows remote PC, don't use the new `/battery` endpoint, or send a PR with the appropriate fixes.
### Backwards compatibility

Other endpoints (`/space`) are not modified, so everything still works as usual.
